### PR TITLE
Minor comment fix in test_c.c

### DIFF
--- a/test/test_c.c
+++ b/test/test_c.c
@@ -60,7 +60,7 @@ bool decode (uint32_t mysize, float drop_prob, uint8_t overhead)
 	const uint16_t symbol_size = 16;
 
 	/*
-	 * Now start decoding things
+	 * Now start encoding things
 	 */
 
 	// use multiple blocks
@@ -295,4 +295,3 @@ int main (void)
 
 	return (ret == true ? 0 : -1);
 }
-


### PR DESCRIPTION
Same as with libRaptorQ.tex, I'm a bit puzzled why it says "Now start decoding things" right before initializing **Encoder** and encoding them ;)
Seem to be a mistake?