### PR TITLE
Misbehaviour when precomputing in background

### DIFF
--- a/test/test_c.c
+++ b/test/test_c.c
@@ -74,7 +74,8 @@ bool decode (uint32_t mysize, float drop_prob, uint8_t overhead)
 	}
 
 	// start background precomputation while we get the source symbols.
-	RaptorQ_precompute (enc, 1, true);
+	// Misbehaviour when precomputing in background detected. 
+	RaptorQ_precompute (enc, 1, false);
 
 	/* everything is encoded now.
 	 * well, it might be running in background, but don't worry:


### PR DESCRIPTION
After several tests I noticed that some executions where failing with an output error message: "core dumped". 
The problem is solved when the precomputation is not done in background. 

This example code also fails when the probability of dropping a packet is 0. (not solved)