### PR TITLE
(Re)define ssize_t as make_signed<size_t>

### DIFF
--- a/src/RaptorQ/v1/common.hpp
+++ b/src/RaptorQ/v1/common.hpp
@@ -97,7 +97,7 @@
 #include <cstdint>
 #include <type_traits>
 //windows does not have ssize_t
-typedef std::conditional<sizeof(size_t) == 4, int32_t, int64_t>::type ssize_t;
+typedef std::make_signed<size_t>::type ssize_t;
 #endif
 
 static const uint64_t RFC6330_max_data = 946270874880;  // ~881 GB


### PR DESCRIPTION
On macOS, the previous code chose `int64_t` as `ssize_t`, and `int64_t` is defined as `long long`, but `ssize_t` had been defined as `long` (despite also being 8 bytes).  This caused the typedef to be non-idempotent.

`make_signed<size_t>` chooses the right counterpart, depending on the base type of `size_t`, e.g. `unsigned long` -> `long`, `unsigned long long` -> `long long`, which is more robust when there are distinct base integer types with the same size.